### PR TITLE
Benchmark QualPal, Petroff and CatPAW; relax the CVD weights for 3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 *.tgz
 bench/palettailor/.cache/
+bench/qualpal/.cache/

--- a/bench/catpaw/readme.md
+++ b/bench/catpaw/readme.md
@@ -1,0 +1,67 @@
+# CatPAW samples
+
+Palettes from CatPAW (Tseng, Wang, Quadri & Szafir, CHI 2026), captured from
+the authors' web tool so the benchmark can score them alongside everything
+else. `samples.json` holds five eight-colour palettes and the settings that
+produced them.
+
+> Tseng, C., Wang, A. Z., Quadri, G. J. and Szafir, D. A. *Redundant is Not
+> Redundant: Automating Efficient Categorical Palettes Design Unifying Color &
+> Shape Encodings with CatPAW.* CHI 2026. `tseng2026catpaw` in
+> [references.bib](../references.bib).
+
+## Why there is no runner here
+
+Every other generator in `bench/` runs headlessly: Palettailor from its own
+sources, Colorgorical from its own Python in Docker, QualPal from PyPI. CatPAW
+cannot, for two reasons.
+
+There is no code release. The paper links a web tool
+(<https://catpaw-categorical-palette.web.app/>) and an anonymised OSF page; it
+does not publish an implementation. The tool's client-side JavaScript could be
+scraped, but it is heavily coupled to the DOM — its logic reads and writes
+jQuery selectors throughout — so running it outside a browser would mean
+reimplementing the selection, and the benchmark would then be measuring the
+reimplementation.
+
+And it is slow. One eight-colour generation takes roughly 40 to 70 seconds in
+the browser, with no seed and no batch mode.
+
+So these five palettes were captured by hand: open the tool, tick
+**Color-only**, set categories to **8**, press **Generate**, and read the
+`fill` off the eight output swatches. Repeat. The recorded values are exactly
+what the tool returned.
+
+## What this sample is not
+
+**Five is not ten, and none of it is seeded.** Every other generator here is
+reported over ten trials from a known seed, reproducible exactly. These five
+are a hand-collected convenience sample from a tool with no seed control.
+Treat the spread as indicative and do not quote a standard deviation from it
+without saying how it was obtained.
+
+**CatPAW is stochastic.** Five presses gave five distinct palettes, so a single
+capture would say very little.
+
+**It selects from a fixed pool.** The output element ids index into the 39
+CIELAB colours in the tool's `colors.js` — the set used in the authors'
+crowdsourced experiments. CatPAW cannot return a colour outside that pool in
+this mode, which bounds how far apart its palettes can be by construction.
+
+## The category error to avoid
+
+**Scoring CatPAW on perceptual distance measures it on an axis it does not
+claim, and the numbers should never be quoted without that sentence attached.**
+
+Its model is built from four crowdsourced experiments on *task accuracy* for
+categorical encodings, and its central finding is that **redundant colour-and-
+shape** encoding beats either channel alone, particularly at five to eight
+categories. Colour-only is the mode its own paper argues against. A palette
+that scores modestly on ΔE here may be doing exactly what CatPAW selected it
+to do: support accurate class-level judgements when paired with a shape.
+
+This benchmark has no shape channel and no measure of task accuracy, so it
+cannot evaluate the thing CatPAW optimizes. What it can honestly say is how
+CatPAW's colour-only output behaves under the distance and simulation choices
+used throughout this directory — which is a statement about this benchmark's
+terms, not a verdict on the tool. `related-work.md` states it that way.

--- a/bench/catpaw/samples.json
+++ b/bench/catpaw/samples.json
@@ -1,0 +1,19 @@
+{
+  "tool": "CatPAW",
+  "url": "https://catpaw-categorical-palette.web.app/",
+  "captured": "2026-09-07",
+  "settings": {
+    "paletteType": "Color-only",
+    "categories": 8,
+    "shapePool": "All (unused in color-only mode)",
+    "mustIncludeColors": []
+  },
+  "method": "Read from the live tool's DOM after each Generate. See readme.md.",
+  "palettes": [
+    ["#244d00", "#eaa1e7", "#323b88", "#6a8283", "#e15d54", "#83f2c2", "#f4c649", "#23896c"],
+    ["#ece639", "#2c477e", "#445221", "#da3628", "#f7abe0", "#984a6c", "#94aabe", "#ef6a6a"],
+    ["#9a717b", "#d7a7d1", "#139779", "#84f5b9", "#583c76", "#ced88f", "#da3a17", "#935361"],
+    ["#a9afad", "#d4b92c", "#41377d", "#f35a29", "#f49679", "#96e1ae", "#e7ecae", "#9e6b99"],
+    ["#81697e", "#21416f", "#e5f144", "#e8552e", "#dc6a73", "#065632", "#e59bcd", "#e5bc25"]
+  ]
+}

--- a/bench/qualpal/generate.py
+++ b/bench/qualpal/generate.py
@@ -1,0 +1,58 @@
+"""Generate one QualPal palette and print it as JSON.
+
+Reads a JSON request on stdin:
+
+    {"n": 8, "h": [0, 360], "c": [0.2, 0.8], "l": [0.3, 0.9],
+     "cvd": {"protan": 1.0, "deutan": 1.0, "tritan": 1.0}, "metric": "ciede2000"}
+
+Calls the extension's `generate_palette_unified` rather than the documented
+`qualpal.Qualpal` class. That is deliberate and load-bearing; see readme.md.
+In qualpal 1.1.0 the Python class validates `cvd`, `metric` and `background`,
+stores them, and then calls C++ entry points whose signatures accept none of
+them, so every setting yields an identical palette. The unified entry point
+takes and honours them.
+"""
+
+import json
+import sys
+
+import _qualpal
+
+
+def main() -> int:
+    req = json.load(sys.stdin)
+    kwargs = {
+        "n": int(req["n"]),
+        "h_range": [float(v) for v in req["h"]],
+        "c_range": [float(v) for v in req["c"]],
+        "l_range": [float(v) for v in req["l"]],
+    }
+    if req.get("cvd"):
+        kwargs["cvd"] = {k: float(v) for k, v in req["cvd"].items()}
+    if req.get("metric"):
+        kwargs["metric"] = req["metric"]
+
+    hexes = _qualpal.generate_palette_unified(**kwargs)
+
+    # A palette that ignored the cvd request would be a silent wrong answer, and
+    # the only visible symptom would be numbers that look plausible. Prove the
+    # option reached the optimizer by generating the same box without it: for
+    # any n worth benchmarking the two must differ.
+    if kwargs.get("cvd"):
+        plain = _qualpal.generate_palette_unified(
+            **{k: v for k, v in kwargs.items() if k != "cvd"}
+        )
+        if list(plain) == list(hexes):
+            print(
+                "qualpal ignored the cvd option: it returned the same palette "
+                "with and without it. See bench/qualpal/readme.md.",
+                file=sys.stderr,
+            )
+            return 2
+
+    json.dump(list(hexes), sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/qualpal/readme.md
+++ b/bench/qualpal/readme.md
@@ -1,0 +1,126 @@
+# QualPal runner
+
+Runs QualPal (Larsson) so the benchmark can score its palettes on the same
+measurements as everything else.
+
+```sh
+node bench/qualpal/run.js --colors 8            # CVD on, search box matched
+node bench/qualpal/run.js --colors 8 --no-cvd   # QualPal's own defaults
+```
+
+From code:
+
+```js
+import { generateQualpal, QUALPAL_DEFAULT_BOX } from './bench/qualpal/run.js';
+const colors = generateQualpal({ colorCount: 8 });
+```
+
+## Where the code comes from
+
+QualPal is C++ with a Python package on PyPI, an R package (`qualpalr`) on
+CRAN, and a web front end at <https://qualpal.cc>. Licensing differs by
+artifact: the C++ sources and the Python package built from them are MIT, and
+the R package is GPL-3. The benchmark uses the Python package. The runner
+installs `qualpal==1.1.0` into a virtualenv under `.cache/` (gitignored) on
+first use and never touches the network again. The version is pinned because
+the option plumbing has changed between releases, and because of the bug below.
+
+It is not the same kind of tool as the others here. Palettailor and this
+library search; QualPal **selects**, taking the *n* most mutually distant
+colors from a sampled grid over an HSL box, maximising the minimum pairwise
+distance. That objective is the one this benchmark reports as `minDeltaE`,
+which makes it the most directly comparable system in the set.
+
+## It is deterministic, so there is no distribution
+
+QualPal takes no seed and returns the same palette for the same arguments every
+time. Where the other generators are reported as mean ± sd over `--trials`
+independent runs, QualPal contributes exactly one palette per configuration.
+Its rows in the results are single values; nothing is being averaged, and a
+standard deviation of zero would be an artifact of that rather than a finding
+about stability.
+
+## The option plumbing is broken in 1.1.0, and this runner routes around it
+
+**`generate.py` calls `_qualpal.generate_palette_unified` directly rather than
+the documented `qualpal.Qualpal` class. That is not a shortcut.**
+
+In qualpal 1.1.0 the Python class accepts `cvd`, `metric` and `background`,
+validates them properly (it rejects an unknown metric, an unknown CVD key, and
+a severity outside 0–1), stores them, and reads them back — and then calls C++
+entry points whose signatures accept none of them:
+
+```
+generate_palette(n, h_range, c_range, l_range)
+generate_palette_from_colors(n, colors)
+```
+
+So every setting produces a byte-identical palette. The clearest symptom is
+that `min_distance` reports the same value under `ciede2000`, `din99d` and
+`cie76`, which those scales cannot all produce for one palette. Asking for
+`deutan: 1.0` on a pool containing a red and a green returns the same selection
+as asking for nothing.
+
+`generate_palette_unified` takes the full option set and honours it. Because a
+silently ignored option would produce plausible-looking numbers rather than an
+error, `generate.py` verifies on every CVD run that the palette actually differs
+from the same box generated without CVD, and fails loudly if it does not. If a
+future version fixes the class, that guard is what will keep this honest;
+switching to the public API is then a one-line change.
+
+Report the version with any QualPal number from this benchmark. Numbers taken
+through the documented Python class in 1.1.0 are CVD-off numbers no matter what
+was requested.
+
+## The two configurations, and why both
+
+| | search box | CVD |
+| --- | --- | --- |
+| `qualpal` | QualPal's own default | protan, deutan, tritan at severity 1 |
+| `qualpal-defaults` | QualPal's own default | off |
+
+**Both rows use the same box and differ only in CVD**, so the gap between them
+measures that one thing. An earlier version of this runner varied the box as
+well — CVD-on in a box matched to this library's, CVD-off in a narrow pastel
+box taken from the R package's documentation — and then described the
+difference as what CVD adaptation buys. It was mostly the box, and the pastel
+box is not any version of QualPal's default. Both errors understated QualPal.
+
+The default is the whole HSL cube, `h 0–360, s 0–1, l 0–1`, read from the
+installed Python source rather than from documentation. That is worth stating
+because it is unusually permissive: QualPal at its defaults will happily return
+near-black and near-white, which is how it reaches a minimum ΔE of 39.6 at
+eight colours. Those are real distances and a real palette; they are also why
+its WCAG contrast numbers are the worst in the benchmark.
+
+## The search-box control
+
+The box is a confound in any comparison against this library, which searches a
+mid-range okhsl region. Measured at 8 colours, all four cells:
+
+| box | CVD | min ΔE | worst deficiency | grayscale | worst of all six |
+| --- | --- | --- | --- | --- | --- |
+| QualPal default | off | 39.6 | 7.3 | 1.2 | 1.2 |
+| QualPal default | on | 24.7 | 21.8 | 0.9 | 0.9 |
+| matched to this library | off | 35.0 | 4.5 | 0.2 | 0.2 |
+| matched to this library | on | 23.7 | 12.6 | 5.2 | 5.2 |
+
+Two things fall out that the headline rows alone would hide. **CVD adaptation
+costs plain separation and buys deficiency headroom** — 39.6 to 24.7 in
+exchange for 7.3 to 21.8 — which is the same trade this library makes with its
+CVD weights, made by a different mechanism. And **constraining the box to this
+library's range is not neutral**: it costs QualPal nine points of worst
+deficiency (21.8 to 12.6) while raising its grayscale (0.9 to 5.2), because a
+mid-range box has less lightness to spend and less room to separate under
+simulation. Neither box is the fair one. Report the tool's own default and
+name the confound.
+
+`node bench/qualpal/run.js --matched-box` and `--no-cvd` set the two axes
+independently, which is what makes the table above reproducible.
+
+## What QualPal cannot be asked to do
+
+Its CVD options are `protan`, `deutan` and `tritan`. There is no grayscale or
+luminance term, so the `grayscale` condition in the results — the print and
+photocopy stand-in — is the one condition it has no way to optimize for. That
+is a scope difference, not a defect: nothing in its documentation claims print.

--- a/bench/qualpal/run.js
+++ b/bench/qualpal/run.js
@@ -1,0 +1,107 @@
+// Headless runner for QualPal (Larsson), so its palettes can be scored by
+// bench/metrics.js alongside everything else.
+//
+//   node bench/qualpal/run.js --colors 8
+//   node bench/qualpal/run.js --colors 8 --no-cvd
+//
+// QualPal is a C++ library with a Python package on PyPI. It is installed into
+// a virtualenv under .cache/ on first use rather than vendored, and pinned to
+// one version because the option plumbing has changed between releases (see
+// readme.md). Unlike the other generators here it takes no seed and is fully
+// deterministic: one configuration yields one palette, not a distribution.
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { createDefaultConfig } from '../../src/index.js';
+
+const VERSION = '1.1.0';
+const CACHE = new URL('.cache/', import.meta.url);
+const VENV = new URL('venv/', CACHE);
+const PYTHON = fileURLToPath(new URL('bin/python', VENV));
+const SCRIPT = fileURLToPath(new URL('generate.py', import.meta.url));
+
+// The Python package's actual default: the whole HSL cube. Taken from the
+// installed source (qualpal/qualpal.py, the `colorspace is None` branch of
+// __init__), not from documentation — the R package documents a different
+// default, and an earlier version of this file benchmarked a narrow pastel box
+// from those docs as though it were the tool's default. That understated
+// QualPal badly, which is the one direction a comparison must never err in.
+export const QUALPAL_DEFAULT_BOX = { h: [0, 360], c: [0, 1], l: [0, 1] };
+
+// A box matched to this library's own working range, so a comparison is not
+// silently a comparison of search spaces. It is only an approximate match:
+// QualPal samples HSL and this library samples okhsl, so equal numbers do not
+// describe equal regions. Matching the extent is the closest fair thing
+// available without reimplementing one tool inside the other's space. Not
+// exported: it is the control behind --matched-box, not part of the runner's
+// interface, and bench/run.js deliberately reports QualPal's own box.
+const matchedBox = () => {
+    const [h, s, l] = createDefaultConfig().colorSpace.ranges;
+    return { h: [...h], c: [...s], l: [...l] };
+};
+
+// Full dichromacy on all three, matching the conditions this library's default
+// config optimizes. QualPal has no grayscale or luminance term, so print is the
+// one condition it cannot be asked to protect.
+export const ALL_CVD = { protan: 1, deutan: 1, tritan: 1 };
+
+const ensureInstalled = () => {
+    if (fs.existsSync(PYTHON)) return;
+    fs.mkdirSync(CACHE, { recursive: true });
+    const venv = spawnSync('python3', ['-m', 'venv', fileURLToPath(VENV)], { stdio: 'inherit' });
+    if (venv.status !== 0) {
+        throw new Error('Could not create a virtualenv for qualpal; is python3 installed?');
+    }
+    const pip = spawnSync(PYTHON, ['-m', 'pip', 'install', '--quiet', `qualpal==${VERSION}`], {
+        stdio: 'inherit',
+    });
+    if (pip.status !== 0) {
+        throw new Error(`Could not install qualpal==${VERSION} from PyPI.`);
+    }
+};
+
+/**
+ * One QualPal palette. Deterministic: the same arguments always return the
+ * same colors, so there is nothing to average over.
+ */
+export const generateQualpal = ({
+    colorCount,
+    cvd = ALL_CVD,
+    colorspace = QUALPAL_DEFAULT_BOX,
+    metric = 'ciede2000',
+} = {}) => {
+    ensureInstalled();
+    const request = JSON.stringify({ n: colorCount, ...colorspace, cvd, metric });
+    const result = spawnSync(PYTHON, [SCRIPT], { input: request, encoding: 'utf8' });
+    if (result.status !== 0) {
+        throw new Error(`qualpal failed: ${(result.stderr || '').trim() || result.status}`);
+    }
+    return JSON.parse(result.stdout);
+};
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    // Same shape as bench/palettailor/run.js: a bad flag is a one-line message
+    // and exit 1, not a stack trace.
+    try {
+        const argv = process.argv.slice(2);
+        const at = (flag) => argv.indexOf(flag);
+        const rawColors = at('--colors') >= 0 ? argv[at('--colors') + 1] : '8';
+        const colorCount = Number(rawColors);
+        if (!Number.isInteger(colorCount) || colorCount < 2) {
+            throw new Error(`--colors needs an integer >= 2; received "${rawColors}".`);
+        }
+        // Box and CVD vary independently. They were once coupled to one flag,
+        // which made the two reported configurations differ in two variables at
+        // once and credited the search box's effect to CVD.
+        const colors = generateQualpal({
+            colorCount,
+            cvd: at('--no-cvd') >= 0 ? null : ALL_CVD,
+            colorspace: at('--matched-box') >= 0 ? matchedBox() : QUALPAL_DEFAULT_BOX,
+        });
+        process.stdout.write(`${JSON.stringify(colors)}\n`);
+    } catch (error) {
+        console.error(`qualpal: ${error.message}`);
+        process.exitCode = 1;
+    }
+}

--- a/bench/readme.md
+++ b/bench/readme.md
@@ -141,6 +141,13 @@ grayscale (2.0 against 0.4), and it is the only reference built under an
 explicit lightness constraint. Okabe-Ito's weakness is grayscale, where orange
 and sky blue collide at 0.4. `related-work.md` has the numbers.
 
+`bench/catpaw` holds five colour-only palettes captured from CatPAW's web
+tool (Tseng et al.), with no runner: the tool has no code release and one
+generation takes the better part of a minute in a browser. Its numbers come
+with a larger caveat than any other comparison here — CatPAW optimizes task
+accuracy under redundant colour-**and-shape** encoding, which this benchmark
+has no way to measure — so read that directory's readme before quoting them.
+
 **No human judgment enters the benchmark or the objective.** Colorgorical,
 CatPAW, and Petroff each ground part of their objective in human ratings:
 pair preference, crowdsourced discriminability, or aesthetic screening. This

--- a/bench/readme.md
+++ b/bench/readme.md
@@ -10,6 +10,7 @@ node bench/run.js --colors 10 --trials 20
 node bench/run.js --format json -o results.json
 node bench/run.js --names 0.5                  # add the name-difference term at weight 0.5
 node bench/run.js --palettailor                # also generate with Palettailor, same seeds
+node bench/run.js --qualpal                    # also generate with QualPal, two configurations
 node bench/run.js --colorgorical               # also score everything on Colorgorical's criteria (Docker)
 ```
 
@@ -80,6 +81,15 @@ GitHub at a pinned commit on first use rather than vendoring it; that readme
 also explains the synthetic data it is given, since Palettailor optimizes a
 palette for a specific chart and this benchmark has none.
 
+`--qualpal` generates with QualPal (Larsson) through its Python package, in two
+configurations: its own shipped defaults, and CVD adaptation on with the search
+box matched to this library's. It is deterministic and takes no seed, so each
+configuration contributes one palette rather than a distribution, and its rows
+are single values. **The runner deliberately bypasses QualPal's documented
+Python class, which in 1.1.0 accepts and validates `cvd`, `metric` and
+`background` and then discards them.** See [bench/qualpal](qualpal/readme.md);
+report the version with any number taken from it.
+
 `--colorgorical` scores every palette in the run, generated and reference, on
 Colorgorical's four criteria (Gramazio, Schloss & Laidlaw, 2017) by running its
 original Python code in Docker, and adds Colorgorical's own sample palettes as
@@ -102,7 +112,8 @@ rules (McNutt et al.). Those rules use a different threshold and a different
 CVD simulation model than this benchmark, so they are useful for asking
 whether a result depends on the choices made here. They are **not** an
 independent validation of the optimizer: an earlier run of them prompted a
-change to the default CVD weights, which makes them an input to the design.
+change to the default CVD weights, which makes them an input to the design, and
+the weights have since been tuned twice.
 See [bench/colorbuddy](colorbuddy/readme.md), and `related-work.md` for what
 the results do and do not support, including the rules this library fails.
 

--- a/bench/readme.md
+++ b/bench/readme.md
@@ -71,6 +71,13 @@ Two choices worth stating plainly, because both affect the comparison:
 - **Reference palettes are truncated, not sampled.** `tableau20` scored at 8
   colors is its first 8, because that is what someone using 8 of its colors
   gets. Sampling the best 8 of 20 would measure a palette nobody uses.
+  Truncated palettes are marked `*` in the table.
+- **Petroff is the exception, and is never truncated.** Petroff publishes a
+  separately optimized cycle per length, so `petroff8` is not the first eight
+  of `petroff10` and truncating one would measure a palette nobody designed or
+  ships. Each is compared only at its own length. It is also the reference that
+  presses hardest on this library's claim: it is the only other palette here
+  built under an explicit grayscale constraint. See `related-work.md`.
 
 ## Other generators
 
@@ -126,11 +133,13 @@ model. A higher minimum ΔE here is evidence that the optimizer separates colors
 well, not that the result is a better palette for every purpose. Any paper using
 these numbers should say so.
 
-The exception is `okabeIto`, which *was* designed for the thing this benchmark
-measures, and is therefore the comparison worth taking seriously. It posts the
-highest plain minimum ΔE of any palette here, including the generated ones, and
-much the best deficiency scores of any reference. Its weakness is grayscale,
-where orange and sky blue collide. `related-work.md` has the numbers.
+The exceptions are `okabeIto` and the `petroff` cycles, which *were* designed
+for the thing this benchmark measures, and are therefore the comparisons worth
+taking seriously. Okabe-Ito is the one readers expect; Petroff is the one that
+presses hardest, beating it on both deficiencies (11.1 against 8.8) and
+grayscale (2.0 against 0.4), and it is the only reference built under an
+explicit lightness constraint. Okabe-Ito's weakness is grayscale, where orange
+and sky blue collide at 0.4. `related-work.md` has the numbers.
 
 **No human judgment enters the benchmark or the objective.** Colorgorical,
 CatPAW, and Petroff each ground part of their objective in human ratings:

--- a/bench/references.bib
+++ b/bench/references.bib
@@ -68,6 +68,30 @@
              https://github.com/IAMkecheng/palettailor-library}
 }
 
+@software{larsson2025qualpal,
+  author  = {Larsson, Johan},
+  title   = {qualpalr: Automatic Generation of Qualitative Color Palettes},
+  year    = {2026},
+  version = {2.0.0},
+  doi     = {10.32614/CRAN.package.qualpalr},
+  url     = {https://github.com/jolars/qualpal},
+  note    = {Software, not a paper: maximises the minimum pairwise distance
+             over a sampled HSL box, with optional protan/deutan/tritan
+             adaptation. Cited because it is the closest competitor measured
+             in bench/ and the only other system there with any CVD handling.
+             PARTIALLY VERIFIED. Confirmed from the CRAN package page: author
+             and maintainer Johan Larsson (ORCID 0000-0002-4029-5945), R
+             package version 2.0.0 dated 29 January 2026, GPL-3, and the DOI
+             above, which is CRAN's own auto-minted package DOI rather than a
+             publication DOI. The C++ sources and the Python package built
+             from them at github.com/jolars/qualpal are MIT per that
+             repository, so the licence differs by artifact; the benchmark
+             uses the Python package, pinned to 1.1.0. NOT yet checked: the
+             citation CRAN advertises under ``qualpalr citation info'', which
+             may name a preferred reference this entry should be replaced by.
+             Check before submission.}
+}
+
 @misc{petroff2021accessible,
   author        = {Petroff, Matthew A.},
   title         = {Accessible Color Sequences for Data Visualization},

--- a/bench/references.bib
+++ b/bench/references.bib
@@ -26,6 +26,10 @@
 % okabe2008cud is a web resource with no DOI or venue and so cannot be checked
 % the same way. Its title, authors and dates are quoted from the page itself.
 %
+% larsson2025qualpal was checked twice. It first carried CRAN's auto-minted
+% package DOI; CRAN advertises a JOSS paper as the preferred citation, and this
+% file now carries that instead, resolved and compared field by field.
+%
 % One field is left out on purpose. The ACM page for tseng2026catpaw gives
 % article number 1155, which Crossref does not carry and which could not be
 % read from dl.acm.org directly, so the entry cites only the page range.
@@ -68,28 +72,27 @@
              https://github.com/IAMkecheng/palettailor-library}
 }
 
-@software{larsson2025qualpal,
+@article{larsson2025qualpal,
   author  = {Larsson, Johan},
-  title   = {qualpalr: Automatic Generation of Qualitative Color Palettes},
-  year    = {2026},
-  version = {2.0.0},
-  doi     = {10.32614/CRAN.package.qualpalr},
-  url     = {https://github.com/jolars/qualpal},
-  note    = {Software, not a paper: maximises the minimum pairwise distance
-             over a sampled HSL box, with optional protan/deutan/tritan
-             adaptation. Cited because it is the closest competitor measured
-             in bench/ and the only other system there with any CVD handling.
-             PARTIALLY VERIFIED. Confirmed from the CRAN package page: author
-             and maintainer Johan Larsson (ORCID 0000-0002-4029-5945), R
-             package version 2.0.0 dated 29 January 2026, GPL-3, and the DOI
-             above, which is CRAN's own auto-minted package DOI rather than a
-             publication DOI. The C++ sources and the Python package built
-             from them at github.com/jolars/qualpal are MIT per that
-             repository, so the licence differs by artifact; the benchmark
-             uses the Python package, pinned to 1.1.0. NOT yet checked: the
-             citation CRAN advertises under ``qualpalr citation info'', which
-             may name a preferred reference this entry should be replaced by.
-             Check before submission.}
+  title   = {Qualpal: Qualitative Color Palettes for Everyone},
+  journal = {Journal of Open Source Software},
+  volume  = {10},
+  number  = {114},
+  pages   = {8936},
+  year    = {2025},
+  doi     = {10.21105/joss.08936},
+  issn    = {2475-9066},
+  url     = {https://joss.theoj.org/papers/10.21105/joss.08936},
+  note    = {Maximises the minimum pairwise distance over a sampled HSL box,
+             with optional protan/deutan/tritan adaptation. The closest
+             competitor measured in bench/ and the only other system there
+             with any CVD handling. Verified: this is the citation CRAN
+             advertises for the qualpalr package, and the DOI resolves to a
+             JOSS paper with matching title, author, volume, issue, article
+             number and year, published 16 October 2025. Licensing differs by
+             artifact -- the C++ sources and the Python package built from
+             them are MIT, the R package is GPL-3. The benchmark uses the
+             Python package, pinned to 1.1.0.}
 }
 
 @misc{petroff2021accessible,

--- a/bench/related-work.md
+++ b/bench/related-work.md
@@ -29,6 +29,16 @@ constraints **including for simulated CVD**, plus minimum-lightness-distance for
 grayscale, maximum-lightness for white-background contrast, and a colour-saliency
 term drawn from the same Heer & Stone model this library uses.
 
+**QualPal** [larsson2025qualpal] maximises the **minimum** pairwise distance
+over a sampled HSL box, with optional protan/deutan/tritan adaptation. It
+selects rather than searches, and it is deterministic. Two things make it the
+most important comparison in this list: its objective is exactly the statistic
+this benchmark reports as the headline number, and it is the only other system
+here that can be asked to protect against colour vision deficiency at all. It
+is also the most available: on PyPI, CRAN and the web, MIT as C++ and
+Python, GPL-3 as the R package. It has no
+luminance or grayscale term, so print is outside its scope. Measured below.
+
 **CatPAW** [tseng2026catpaw] derives palettes from four crowdsourced experiments
 on redundant colour–shape encoding. Newest of the group and from Szafir's lab;
 worth reading before submitting anything.
@@ -68,12 +78,14 @@ annealing to categorical palette generation" describes prior art.
 What is plausibly distinctive, in rough order of strength:
 
 1. **CVD robustness as weighted objective terms rather than constraints.** The
-   default config carries three JND terms — unimpaired, protanomaly 0.5, and
-   deuteranomaly 0.5, the last at the highest weight. Petroff treats CVD as a
-   *constraint* to satisfy; here it is a cost to trade off, so the optimizer
-   will accept a slightly worse unimpaired palette for a much better
-   deuteranomalous one. That trade is the interesting behaviour and it is
-   measurable — it is what the CVD column of the benchmark shows.
+   default config carries five JND terms: unimpaired at weight 1, protanopia,
+   deuteranopia and tritanopia at 0.1 each, and grayscale at 0.05. Petroff and
+   QualPal both treat CVD as something to satisfy — a constraint and a
+   simulation-before-selection respectively; here it is a cost to trade off,
+   which is why the weights can be tuned against measurement rather than set
+   once. **The grayscale term is the part with no equivalent anywhere in the
+   comparison set**, and it is the one that survives contact with QualPal.
+   Claim the print axis, not CVD in general.
 2. **Channel locking.** Holding a brand hue fixed while saturation and lightness
    move to satisfy contrast is a real practitioner constraint the cited
    generators do not expose.
@@ -140,32 +152,86 @@ different model and threshold say" below for what it can and cannot support.
 the same seeds (see `bench/palettailor/readme.md` for how it is fed data it
 was never designed to run without). At 8 colours, ten trials, seed 1:
 
-- **Palettailor wins on plain minimum ΔE**, 26.6 ± 2.4 against 19.0 ± 1.5, and
-  the gap widened when the defaults here took on the CVD terms. It searches
-  lightness 35–95 and any chroma while this config works a mid-range okhsl box
-  and now spends much of its budget on four simulated conditions. State this
-  plainly rather than burying it.
-- **It loses badly the moment any deficiency is simulated.** Worst case across
-  every condition: 1.2 ± 1.1 against 7.9 ± 0.3. Under deuteranopia 5.8 against
-  16.1, protanopia 9.2 against 16.2, tritanopia 10.5 against 17.2, grayscale
-  1.2 against 7.9. Palettailor has no CVD term at all, and its numbers sit
-  among the hand-designed reference palettes.
-- **On name difference Palettailor is now ahead**, 0.34 ± 0.16 against
-  0.16 ± 0.12. It optimizes name difference and this config does not, and the
-  CVD terms cost it: the same measurement was 0.36 before they were added.
-  `--names 0.5` recovers it, and the paper should either enable that term or
-  concede the point.
+- **Palettailor still wins on plain minimum ΔE**, 26.6 ± 2.4 against 22.6 ± 1.6.
+  The gap narrowed sharply when the 3.0 defaults relaxed the CVD weights, but
+  it did not close, and part of what remains is a difference of search spaces
+  rather than search methods: Palettailor works lightness 35–95 at any chroma
+  while this config works a mid-range okhsl box. State it plainly rather than
+  burying it.
+- **It loses the moment any deficiency is simulated.** Worst case across every
+  condition: 1.2 ± 1.1 against 7.7 ± 0.3. Under deuteranopia 5.8 against 16.3,
+  protanopia 9.2 against 14.9, tritanopia 10.5 against 15.6, grayscale 1.2
+  against 7.7. Palettailor has no CVD term at all, and its numbers sit among
+  the hand-designed reference palettes.
+- **On name difference the two are now level**, 0.34 ± 0.16 against 0.35 ± 0.14.
+  This is new, and it is a side effect rather than an achievement: 2.0.1
+  measured 0.16 here and the 3.0 reweighting lifted it without a `names` term
+  in the objective at all. Spreading colours further apart in ΔE tends to move
+  them apart in naming too. Do not claim it as a designed property, and note
+  that `--names 0.5` remains the way to optimize it deliberately.
 
-So the trade is explicit: this library gives up plain separation and
-nameability to hold every simulated condition above 7.9, where the closest
-competitor drops to 1.2. Whether that is the right trade depends on the
-reader's audience, which is an argument worth making directly rather than
-winning on a single column. Two further caveats: the
-lightness-range difference means the plain min-ΔE comparison is partly a
-comparison of search spaces, not search methods; and Palettailor's annealing
-schedule accepts nearly every move for the first 60% of its run, so it is
-closer to a short hill-climb than to the annealing this library does — see the
-runner's readme for what its code actually does.
+Two further caveats: Palettailor's annealing schedule accepts nearly every move
+for the first 60% of its run, so it is closer to a short hill-climb than to the
+annealing this library does; and it is data-dependent, so a benchmark with no
+data hides the advantage it was actually built for — spending contrast on the
+classes that touch. See the runner's readme.
+
+## QualPal, measured
+
+`node bench/run.js --qualpal` runs QualPal (Larsson) through its Python
+package. It is the most important comparison here and the least comfortable
+one. See `bench/qualpal/readme.md` for the runner, including why it bypasses
+the documented Python class.
+
+It is not a search. QualPal selects the *n* most mutually distant colours from
+a sampled HSL box, maximising the minimum pairwise distance — which is exactly
+the statistic this benchmark reports as its headline number. It is also
+deterministic: one configuration gives one palette, so its rows are single
+values with nothing averaged.
+
+Both reported configurations use QualPal's own default colorspace and differ
+only in whether CVD adaptation is on, so the gap between them measures that
+one thing:
+
+| | min ΔE | worst deficiency | grayscale | worst of all six |
+| --- | --- | --- | --- | --- |
+| category-colors 3.0 | 22.6 ± 1.6 | 13.7 ± 2.0 | **7.7 ± 0.3** | **7.7 ± 0.3** |
+| qualpal, CVD on | 24.7 | **21.8** | 0.9 | 0.9 |
+| qualpal, CVD off (ships) | **39.6** | 7.3 | 1.2 | 1.2 |
+
+- **QualPal beats this library on plain separation and on deficiencies, and it
+  is not close on either.** 24.7 against 22.6, and worst deficiency 21.8
+  against 13.7 — a 60% margin. Every one of our ten trials, from 9.9 to 16.1,
+  falls below its 21.8. There is no reading of these rows in which this library
+  is the better tool for colour vision deficiency, and any draft that implies
+  otherwise is wrong.
+- **What it does not do is print.** Grayscale 0.9 with CVD on, 1.2 without,
+  against 7.7 here. QualPal's CVD options are protan, deutan and tritan; it has
+  no luminance term, so nothing in it defends the one condition a photocopier
+  applies. Turning its CVD adaptation on makes grayscale slightly *worse*
+  (1.2 to 0.9), because separating under three dichromacies spends the same
+  lightness budget that grayscale needs.
+- **The claim reduces to one axis.** Worst pair across all six conditions:
+  7.7 against 0.9 and 1.2. That gap is real and large, and it comes entirely
+  from the grayscale term. Say "print", not "accessibility".
+- **Its defaults are permissive, not conservative.** The default box is the
+  whole HSL cube, so QualPal will return near-black and near-white; that is how
+  it reaches 39.6. The same freedom gives it the worst WCAG contrast in the
+  benchmark, 1.13 against white, and a minimum name difference of 0.10 with CVD
+  on — two of its eight colours get the same name.
+
+An earlier version of this section reported QualPal in a search box matched to
+this library's, which cost it nine points of worst deficiency (21.8 to 12.6)
+and made this library look narrowly ahead on that axis. It never was. The box
+remains a genuine confound in the other direction — QualPal's default cube is
+far larger than the mid-range okhsl region searched here — and
+`bench/qualpal/readme.md` carries all four cells. Name the confound; do not
+resolve it by picking the box that flatters.
+
+The honest summary: **QualPal is a better categorical palette generator than
+this one on every axis it models, and the only thing it does not model is
+print.** That is the claim that survives, and it is much narrower than
+"accessibility". Write it that way before a reviewer does it for you.
 
 ## Colorgorical, cross-scored
 
@@ -175,24 +241,34 @@ its four criteria, each the minimum over pairs. Same run as above:
 
 | | ΔE | name diff | pair pref | name uniq |
 | --- | --- | --- | --- | --- |
-| category-colors | 18.6 ± 2.2 | 0.50 ± 0.10 | −44 ± 6 | 0.57 ± 0.08 |
+| category-colors 3.0 | 22.7 ± 2.2 | 0.60 ± 0.09 | −50 ± 7 | 0.50 ± 0.09 |
+| qualpal (CVD on) | 23.2 | 0.61 | −85 | 0.56 |
+| qualpal (defaults) | 20.4 | 0.41 | −54 | 0.59 |
 | palettailor | 26.6 ± 2.8 | 0.63 ± 0.13 | −67 ± 8 | 0.27 ± 0.10 |
 | colorgorical (own samples) | 15.8 ± 3.2 | 0.45 ± 0.07 | −23 ± 9 | 0.41 ± 0.11 |
 | best reference | 19.7 (observable10) | 0.70 (d3) | −13 (tableau20) | 0.59 (ColorBrewer) |
 
 And the reverse direction, Colorgorical's ten 8-colour sample palettes at its
 all-equal slider setting scored on this benchmark's metrics: minimum ΔE
-15.8 ± 3.3 against 19.0 here, worst case across every simulated condition
-0.9 ± 0.6 against 7.9 ± 0.3, and cosine name difference 0.09 ± 0.06 against
-0.16 — its closest-named pair is usually two shades of the same name.
+15.8 ± 3.3 against 22.6 here, worst case across every simulated condition
+0.9 ± 0.6 against 7.7 ± 0.3, and cosine name difference 0.09 ± 0.06 against
+0.35 — its closest-named pair is usually two shades of the same name.
 
-Note that this library's Colorgorical scores moved when its defaults took on
-the CVD terms, and not all in one direction: ΔE fell from 24.0 to 18.6 and
-name difference from 0.61 to 0.50, while pair preference improved from −58 to
-−44 and name uniqueness from 0.52 to 0.57. Spreading lightness evenly appears
-to help on the two criteria grounded in human ratings, which is a happy
-accident rather than something the objective asked for, and should be
-described as one.
+These scores have now moved twice with this library's defaults, in opposite
+directions, which is worth stating rather than reporting only the current
+row. Taking on the CVD terms in 2.0 pushed ΔE from 24.0 down to 18.6 and name
+difference from 0.61 to 0.50 while improving pair preference and name
+uniqueness; relaxing those weights in 3.0 moved ΔE back to 22.7 and name
+difference to 0.60, and gave back most of the pair-preference and
+name-uniqueness gains (−44 to −50, 0.57 to 0.50). **None of these four
+criteria is in the objective.** They move as side effects of how far apart the
+palette is spread, which is a reason to report them and not a reason to claim
+them.
+
+QualPal's row is the interesting one: it leads on ΔE and name difference and
+posts the worst pair preference of anything measured here, −85. Maximising a
+minimum pushes colours to the extremes of the box, and the extremes are not
+where people say they like colours.
 
 Three things to know before quoting these:
 
@@ -228,9 +304,24 @@ before anyone else states it for us:
 
 > Given a just-noticeable-difference threshold of 20, CIEDE2000 distance in
 > CIELAB D65, and Machado et al. (2009) as the color vision deficiency model,
-> this optimizer produces palettes that score better on those terms than the
-> established categorical palettes and than the two published generators that
-> solve the same problem.
+> this optimizer produces eight-colour palettes whose **worst pair across
+> unimpaired vision, five simulated deficiencies and a grayscale projection**
+> is higher than that of any established categorical palette or any of the
+> three published generators measured here.
+
+That is the strongest form still standing, and it is deliberately not "better
+palettes". Three things it does **not** claim, each because a measurement here
+says otherwise:
+
+- Not that it wins on plain separation. Palettailor (26.6) and QualPal (24.7
+  with CVD on, 39.6 without) both beat it, and it leads Okabe-Ito only on the
+  mean of ten trials.
+- Not that it is the best on colour vision deficiency. QualPal is far better:
+  worst deficiency 21.8 against 13.7, with all ten of our trials below its
+  figure. **Grayscale is the only axis with a structural gap**, because no
+  other system measured has a luminance term at all.
+- Not that any of this is validated by a third party. See the color-buddy
+  section: that tool has been an input to these weights twice.
 
 Every part of that is a **choice**, not a discovery. The threshold comes from
 Stone, Szafir & Setlur [stone2014engineering]; the distance metric from
@@ -247,41 +338,47 @@ so beating them on it proves little. **Okabe & Ito's Color Universal Design
 set was**, and it is the palette a reviewer will ask about first. It is in the
 benchmark as `okabeIto`.
 
-It is by some distance the best of the references, and it beats this library
-where this library is weakest:
+It is by some distance the best of the references:
 
 | | min ΔE | worst deficiency | grayscale |
 | --- | --- | --- | --- |
-| okabeIto | **21.3** | 8.8 | 0.4 |
-| category-colors | 19.0 ± 1.5 | 12.5 to 16.4 | 7.9 |
-| carbon | 12.8 | 5.0 | 2.5 |
-| tableau10 | 18.1 | 3.2 | 0.5 |
+| category-colors 3.0 | 22.6 ± 1.6 | 9.9 to 16.1 | **7.7** |
+| okabeIto | 21.3 | 8.8 | 0.4 |
 | observable10 | 18.4 | 0.6 | 0.7 |
-| colorBrewer3_10 | 13.7 | 1.9 | 0.1 |
+| tableau10 | 18.1 | 3.2 | 0.5 |
 | d3category10 | 16.2 | 1.6 | 0.0 |
+| colorBrewer3_10 | 13.7 | 1.9 | 0.1 |
+| carbon | 12.8 | 5.0 | 2.5 |
 | tableau20 | 12.6 | 0.6 | 0.8 |
 
-Three readings, and the first is not in our favour:
+Three readings. The first changed with 3.0 and the change should be described
+carefully, because overstating it is the easiest mistake available here:
 
-- **Okabe-Ito has the highest plain minimum ΔE of anything measured here**,
-  21.3, above this library's ten-trial mean of 19.0 and above its best trial of
-  21.6 only barely. A hand-designed palette from 2008 beats the optimizer on
-  the headline number. Say so.
-- **On the deficiencies the optimizer is still ahead, without overlap.** Worst
-  case across the five deficiency conditions, our ten palettes run 12.5 to
-  16.4 against Okabe-Ito's 8.8. It is roughly twice as good as the next
-  reference (carbon at 5.0), which is exactly what a palette designed for the
-  purpose should look like, and we are roughly 1.4 to 1.9 times better again.
+- **The optimizer now leads on plain minimum ΔE, on the mean.** 22.6 ± 1.6
+  against 21.3. Through 2.0.x this comparison went the other way and the note
+  here read "a hand-designed palette from 2008 beats the optimizer on the
+  headline number". It no longer does — but **four of our ten trials land at or
+  below 21.3** (20.7, 21.3, 21.3, 21.3), so the correct claim is that the
+  distribution is centred above Okabe-Ito, not that a generated palette beats
+  it. Anyone quoting a single run has a 40% chance of quoting a tie or a loss.
+- **On the deficiencies the optimizer is ahead, and still without overlap.**
+  Worst case across the five deficiency conditions, our ten palettes run 9.9 to
+  16.1 against Okabe-Ito's 8.8. The floor moved down with the 3.0 reweighting —
+  it was 12.5 — so the margin is now one trial wide at the bottom. It is worth
+  saying that this was a deliberate trade and that the bottom of the range is
+  where it shows.
 - **Okabe-Ito is not safe in grayscale**, at 0.4. The collision is orange
   `#e69f00` against sky blue `#56b4e9`, two colors of nearly equal luminance,
   and it is not an artifact of the gray swatch: the seven chromatic colors
   alone score the same. Photocopy an Okabe-Ito figure and two categories merge.
   That is a real gap and it is the one this library's grayscale term closes,
-  7.9 against 0.4.
+  7.7 against 0.4. **This is the least contested finding in the whole
+  benchmark** — no reference palette exceeds 2.5, and no other generator has a
+  luminance term at all.
 
-The honest summary is that Okabe-Ito wins on unaided separation, this library
-wins on every simulated condition, and the gap on grayscale is large enough to
-matter for print.
+The honest summary is that this library now leads Okabe-Ito on average on
+unaided separation and on every simulated condition, and that the grayscale gap
+is the one large enough to carry an argument on its own.
 
 ## The result does not depend on the threshold
 
@@ -292,26 +389,31 @@ eight colors:
 
 | | worst pair per palette, sorted |
 | --- | --- |
-| category-colors | 7.0 7.8 7.9 7.9 8.0 8.0 8.0 8.0 8.0 8.0 |
+| category-colors 3.0 | 7.2 7.3 7.5 7.6 7.7 7.8 7.8 7.9 7.9 8.0 |
+| qualpal, CVD on | 0.9 (deterministic) |
 | palettailor | 0.2 0.2 0.3 0.4 0.4 1.3 1.6 1.6 2.6 3.4 |
 | colorgorical | 0.2 0.3 0.5 0.8 0.8 0.9 1.0 1.1 1.1 2.6 |
+| qualpal, defaults | 1.2 (deterministic) |
 
-**The distributions do not overlap**, and neither do they against Okabe-Ito
-once grayscale is excluded to compare like with like: 12.5 to 16.4 against 8.8.
-Any cutoff between 3.4 and 7.0 separates the generators completely, so the
-ranking survives any reasonable choice of threshold, including one chosen by
-someone hostile to it. Ten of ten Palettailor palettes and ten of ten
+**The distributions do not overlap.** Any cutoff between 3.4 and 7.2 separates
+this library from everything else measured, so the ranking survives any
+reasonable choice of threshold, including one chosen by someone hostile to it.
+This is the *only* measurement on which QualPal does not lead, and it is
+carried entirely by the grayscale condition: across the five deficiencies alone
+QualPal's floor is 21.8 against our 9.9. Ten of ten Palettailor palettes and ten of ten
 Colorgorical palettes contain a pair below ΔE 5 under some condition; eight
 and nine of ten respectively fall below 2, which is two colors nobody can tell
 apart. None of ours falls below 7.
 
 This is also the number to quote rather than a count of failing pairs, because
 a count says something different and weaker. Counting pairs below 20, out of
-280, this library and Palettailor are effectively tied: 13% against 12% under
-deuteranopia, 13% against 11% under protanopia, and Palettailor is *better*
-with no simulation at all, 0% against 4%. Its palettes are more spread out on
-average and catastrophic in the tail. Ours are tighter on average with no
-catastrophic pair. Since a palette fails on its worst pair, the tail is what
+280, this library and Palettailor are effectively tied: 14% against 12% under
+deuteranopia, 13% against 11% under protanopia, and both are now at 0% with no
+simulation at all. Palettailor's palettes are more spread out on average and
+catastrophic in the tail. Ours are tighter on average with no catastrophic
+pair. QualPal with CVD on posts the best counts of anything measured — 0%, 0%
+and 4% — but from a single palette of 28 pairs rather than 280, so the number
+carries far less weight than the others in this paragraph. Since a palette fails on its worst pair, the tail is what
 matters — the same reason the benchmark reports minima rather than means.
 
 ## What a different model and threshold say
@@ -319,25 +421,43 @@ matters — the same reason the benchmark reports minima rather than means.
 `bench/colorbuddy` runs color-buddy's published lint rules, which make
 different choices than we do: a threshold of 9 rather than 20, and an
 LMS-matrix dichromacy model from `@bjornlu/colorblind` rather than Machado.
-Under those different choices the ranking is the same. All three dichromacy
-rules pass for ten of ten generated palettes; no reference palette passes more
-than one, and Palettailor passes protanopia three times in ten, deuteranopia
-once.
+Under those different choices the ranking is the same, but **the 3.0
+reweighting cost real ground here and it should be reported, not buried**:
+
+| rule | 2.0.1 | 3.0 |
+| --- | --- | --- |
+| Protanopia-friendly | 10/10 | 10/10 |
+| Deuteranopia-friendly | 10/10 | **8/10** |
+| Tritanopia-friendly | 10/10 | **8/10** |
+| Right in black and white | 0/10 | 0/10 |
+
+No reference palette passes more than one dichromacy rule, and Palettailor
+passes protanopia three times in ten and deuteranopia once, so the ordering is
+unchanged. But two of ten generated palettes now fail rules that all ten passed
+before. Under our own model and threshold the same trade looks almost free
+(worst case across conditions moved 7.9 to 7.7); under color-buddy's threshold
+of 9 and a different simulation model it costs two palettes in ten on two
+rules. **That divergence is the most useful thing this runner has produced**,
+because it shows the relaxation is closer to the edge than our own numbers
+suggest. If the deficiency margin matters more than the 3.6 points of ordinary
+separation 3.0 bought, the sweep behind that change found settings around
+`jnd 0.7 / dichromacy 0.15 / tritanopia 0.05` that keep worst-deficiency near
+14 for about a point and a half less unimpaired separation.
 
 **This is not independent validation, and must not be presented as such.**
-An earlier run of this same lint is what prompted re-examining the CVD weights,
-which led to the defaults changing from anomaly at half severity to full
-dichromacy. The tool is therefore an input to the design. What it can honestly
-support is narrower: that the result is not an artifact of our particular
-threshold or our particular simulation model, since a different pair of both
-ranks the palettes the same way. Disclose the sequence, in the paper, before a
+An earlier run of this same lint is what prompted re-examining the CVD weights
+in 2.0, and the weights have since been tuned twice against measurements this
+project chose. The tool is therefore an input to the design, not a check on it.
+What it can honestly support is narrower: that the *ranking* is not an artifact
+of our particular threshold or simulation model, since a different pair of both
+orders the palettes the same way. Disclose the sequence, in the paper, before a
 reviewer finds it in the commit history.
 
 Two of its rules this library fails, and they are worth reporting:
 
 - **`cvd-friendly-grayscale` is unreachable**, not merely failed. It requires
   every pair to differ by more than 9 after a grayscale projection. Adding a
-  grayscale term lifted our own grayscale minimum from 0.8 to about 7.9, and
+  grayscale term lifted our own grayscale minimum from 0.8 to about 7.7, and
   it plateaus there at any weight: eight colors cannot be spread far enough in
   lightness alone while the other terms hold. The references sit between 0.0
   and 2.5, with two of `d3category10`'s colors identical in grayscale, so the
@@ -361,17 +481,33 @@ than as a scoring system, and should not be cited as one.
 
 - **A manual pass on the three citations with no DOI**, named in the header
   of `references.bib`.
-- **Decide whether the new default trade is the right one for the paper's
-  headline.** Modeling the dichromacies, tritanopia and grayscale cost 4.8
-  points of unimpaired minimum ΔE, from 23.8 to 19.0, which is close to
-  `tableau10` at 18.1 and `observable10` at 18.4. The CVD numbers are far
-  better and the worst case across every condition is 7.9 against at best 2.5
-  for any reference, so the trade looks right; but "we beat the references on
-  plain minimum ΔE" is no longer the comfortable claim it was, and the paper
-  should lead with the worst-case-across-conditions number instead.
+- **Decide whether 3.0's weights are where the paper wants to stand.** They
+  buy 3.6 points of unimpaired separation (19.0 to 22.6) for 0.2 of worst-case
+  (7.9 to 7.7) on our own measurements — but two of ten palettes now fail
+  color-buddy's deuteranopia and tritanopia rules, which all ten passed at
+  2.0.1, and all ten fall below QualPal on worst deficiency. The trade still
+  looks right, and the paper should lead with worst-case-across-conditions
+  either way, but the argument is now "we chose a point on a frontier" rather
+  than "this is free". Say which, and show the frontier.
+- **A QualPal sensitivity pass.** Its numbers come from one deterministic
+  palette per configuration. Varying `colorspace_size` and the box would show
+  whether 24.7 is a stable property or a lucky grid, and it is the first thing
+  a reviewer who knows the tool will ask.
+- **Resolve the `qualpalr` citation.** `references.bib` carries a CRAN package
+  DOI; CRAN also advertises a preferred citation that has not been read yet.
+- **Petroff and CatPAW are still unmeasured.** Petroff is the closer gap: it
+  optimizes grayscale explicitly, which is the one axis this work is now
+  claiming, so it is the strongest untested threat to the central claim.
 
 ## Done since the first draft
 
+- **QualPal comparison** (`bench/qualpal`), in two configurations, after
+  finding that its Python package silently drops every option including `cvd` —
+  see that runner's readme. It is the strongest competitor measured and it
+  narrowed the claim to the print axis.
+- **The default CVD weights relaxed in 3.0**, on the measurement that they had
+  saturated: worst case is pinned to grayscale in every configuration, so the
+  red-green terms were defending a margin nothing was contesting.
 - **Palettailor comparison**, **Colorgorical cross-scoring** and a
   **color-buddy run**, reported as a robustness check under a different
   threshold and simulation model rather than as validation — above.

--- a/bench/related-work.md
+++ b/bench/related-work.md
@@ -39,9 +39,12 @@ is also the most available: on PyPI, CRAN and the web, MIT as C++ and
 Python, GPL-3 as the R package. It has no
 luminance or grayscale term, so print is outside its scope. Measured below.
 
-**CatPAW** [tseng2026catpaw] derives palettes from four crowdsourced experiments
-on redundant colour–shape encoding. Newest of the group and from Szafir's lab;
-worth reading before submitting anything.
+**CatPAW** [tseng2026catpaw] derives palettes from four crowdsourced
+experiments on redundant colour–shape encoding, and is the only system here
+grounded in measured task *accuracy* rather than preference or distance. Its
+finding is that colour-and-shape together beats either alone at five to eight
+categories, so its colour-only mode is the one it argues against. A web tool,
+no code release. Measured below, with the caveats that implies.
 
 ### Perceptual foundations
 
@@ -278,6 +281,50 @@ published palette, not a distribution: like QualPal it is a fixed artifact, and
 unlike QualPal it was never run as a generator, because the code takes several
 thousand CPU hours. That is a real limit on this comparison and should be
 disclosed rather than glossed.
+
+## CatPAW, measured on terms it does not claim
+
+CatPAW [tseng2026catpaw] is the newest neighbour and the last one unmeasured.
+Five colour-only eight-colour palettes are recorded in
+`bench/catpaw/samples.json`, captured by hand from the authors' web tool;
+`bench/catpaw/readme.md` explains why there is no runner and what the sample
+is not.
+
+| | min ΔE | worst deficiency | grayscale | worst of all six |
+| --- | --- | --- | --- | --- |
+| category-colors 3.0 | 22.6 ± 1.6 | 13.7 ± 2.0 | 7.7 ± 0.3 | 7.7 ± 0.3 |
+| catpaw, colour-only | 14.3 ± 2.2 | 6.4 ± 1.4 | 0.8 ± 0.6 | 0.8 ± 0.6 |
+
+**These numbers are not a comparison of quality, and the paper should say so in
+the same breath it gives them.** CatPAW's model comes from four crowdsourced
+experiments on *task accuracy*, and its central claim is that redundant
+colour-**and-shape** encoding beats either channel alone at five to eight
+categories. Colour-only is the mode its own authors argue against. This
+benchmark has no shape channel and no accuracy measure, so it cannot evaluate
+what CatPAW optimizes. Scoring it here is like scoring Palettailor without
+data, only more so.
+
+Three things the measurement does support:
+
+- **It selects from a fixed pool of 39 colours**, the set used in the authors'
+  experiments (the tool's `colors.js`, confirmed by the output element ids
+  indexing into it). A palette drawn from 39 fixed points cannot spread as far
+  as one searching a continuous space, which bounds `minDeltaE` by
+  construction rather than by any choice about accessibility.
+- **Nothing in it models colour vision deficiency or print.** Worst case across
+  conditions is 0.8, and one of the five palettes contains a pair that
+  vanishes completely under some condition (0.0). If a reader needs the palette
+  to survive simulation, CatPAW as it stands does not provide that, and does
+  not claim to.
+- **It is the only system here grounded in measured human performance rather
+  than preference.** Colorgorical models what people *like*; CatPAW models what
+  people get *right*. That is the more interesting scope gap for this library,
+  which models neither.
+
+The honest framing: CatPAW and this library answer different questions, and the
+comparison worth making is not ΔE but whether palettes optimized for perceptual
+distance also support the class-level judgements CatPAW's experiments measure.
+That is an empirical question this benchmark cannot answer.
 
 ## Colorgorical, cross-scored
 
@@ -535,8 +582,6 @@ than as a scoring system, and should not be cited as one.
 
 ## What the benchmark still needs
 
-- **A manual pass on the three citations with no DOI**, named in the header
-  of `references.bib`.
 - **Decide whether 3.0's weights are where the paper wants to stand.** They
   buy 3.6 points of unimpaired separation (19.0 to 22.6) for 0.2 of worst-case
   (7.9 to 7.7) on our own measurements — but two of ten palettes now fail
@@ -549,14 +594,25 @@ than as a scoring system, and should not be cited as one.
   palette per configuration. Varying `colorspace_size` and the box would show
   whether 24.7 is a stable property or a lucky grid, and it is the first thing
   a reviewer who knows the tool will ask.
-- **Resolve the `qualpalr` citation.** `references.bib` carries a CRAN package
-  DOI; CRAN also advertises a preferred citation that has not been read yet.
-- **Petroff and CatPAW are still unmeasured.** Petroff is the closer gap: it
-  optimizes grayscale explicitly, which is the one axis this work is now
-  claiming, so it is the strongest untested threat to the central claim.
+- **Both remaining neighbours are now measured, and both carry asterisks.**
+  Petroff's palettes were scored as published artifacts rather than
+  regenerated, because generating them takes several thousand CPU hours.
+  CatPAW was captured by hand from its web tool — five palettes rather than ten
+  seeded trials — and scored on an axis it does not claim. Neither is as solid
+  as the Palettailor, QualPal or Colorgorical comparisons. Label them as weaker
+  evidence wherever they appear.
+- **The comparison this benchmark cannot make.** CatPAW measures task accuracy
+  under redundant colour-shape encoding; Colorgorical and Petroff both model
+  human preference. This library models neither. `bench/readme.md` states that
+  as a scope choice, but three of the five neighbours now carry a
+  human-grounded term, which starts to look less like a scope choice and more
+  like the direction of the field.
 
 ## Done since the first draft
 
+- **Petroff and CatPAW measured**, closing the last two gaps in the neighbour
+  set — Petroff as published palettes now in `palettes`, CatPAW as a recorded
+  sample in `bench/catpaw` with the category error stated up front.
 - **QualPal comparison** (`bench/qualpal`), in two configurations, after
   finding that its Python package silently drops every option including `cvd` —
   see that runner's readme. It is the strongest competitor measured and it

--- a/bench/related-work.md
+++ b/bench/related-work.md
@@ -233,6 +233,52 @@ this one on every axis it models, and the only thing it does not model is
 print.** That is the claim that survives, and it is much narrower than
 "accessibility". Write it that way before a reviewer does it for you.
 
+## Petroff, measured
+
+Petroff [petroff2021accessible] is the nearest published work to this
+library's objective and, until now, the largest untested threat to its claim:
+it is the only other palette here built under an **explicit grayscale
+constraint**. `petroff6`, `petroff8` and `petroff10` are in `palettes`, quoted
+from the "Final results" of the author's repository (MIT).
+
+Unlike every other reference, each length is a separate optimization —
+`petroff8` is not the first eight of `petroff10` — so the benchmark compares
+them only at their own length instead of truncating.
+
+At eight colours:
+
+| | min ΔE | worst deficiency | grayscale | worst of all six |
+| --- | --- | --- | --- | --- |
+| category-colors 3.0 | 22.6 ± 1.6 | 13.7 ± 2.0 | **7.7 ± 0.3** | **7.7 ± 0.3** |
+| petroff8 | 20.0 | **11.1** | 2.0 | 2.0 |
+| okabeIto | 21.3 | 8.8 | 0.4 | 0.4 |
+| carbon | 12.8 | 5.0 | 2.5 | 2.5 |
+
+- **Petroff is the best reference palette on colour vision deficiency**, 11.1
+  against Okabe-Ito's 8.8 and roughly twice the next non-Okabe-Ito reference.
+  Its grayscale of 2.0 also beats every other reference. On the axis this
+  library claims, it is the closest thing to a peer in the published set.
+- **The grayscale claim survives, but narrowly and for a reason worth stating.**
+  2.0 against 7.7 is a real gap, but it is a difference of degree, not of kind:
+  Petroff *has* a lightness constraint and simply sets it low. The 8-colour
+  cycle was generated with `--min-light-dist 4.2`, a floor on CAM02-UCS
+  lightness separation, where this library minimizes a CIEDE2000 distance after
+  a luminance projection and pushes it to about 7.7. **Different quantity,
+  different threshold.** Do not write "Petroff does not handle grayscale"; write
+  that its constraint is a lower one, measured differently.
+- **This is the comparison to lead the related work with**, not Okabe-Ito.
+  Okabe-Ito is the palette reviewers ask about; Petroff is the one that shares
+  the objective, and beating it by 5.7 points of grayscale while losing 2.6 to
+  QualPal on plain separation is the honest shape of the result.
+
+Petroff also carries an aesthetic-preference model trained on a survey, which
+is a human-grounded term this library has nothing equivalent to — the same
+scope gap as Colorgorical's pair preference. Its numbers here are for one
+published palette, not a distribution: like QualPal it is a fixed artifact, and
+unlike QualPal it was never run as a generator, because the code takes several
+thousand CPU hours. That is a real limit on this comparison and should be
+disclosed rather than glossed.
+
 ## Colorgorical, cross-scored
 
 `node bench/run.js --colorgorical` runs Colorgorical's original Python code in
@@ -320,6 +366,9 @@ says otherwise:
   worst deficiency 21.8 against 13.7, with all ten of our trials below its
   figure. **Grayscale is the only axis with a structural gap**, because no
   other system measured has a luminance term at all.
+- Not that the grayscale gap is a difference of kind. Petroff constrains
+  lightness separation explicitly and reaches 2.0 against 7.7 here; the
+  distance is a lower threshold on a different quantity, not an absent one.
 - Not that any of this is validated by a third party. See the color-buddy
   section: that tool has been an input to these weights twice.
 
@@ -338,12 +387,19 @@ so beating them on it proves little. **Okabe & Ito's Color Universal Design
 set was**, and it is the palette a reviewer will ask about first. It is in the
 benchmark as `okabeIto`.
 
+It is no longer the toughest reference, though: `petroff8` beats it on worst
+deficiency, 11.1 against 8.8, and on grayscale, 2.0 against 0.4. Okabe-Ito is
+the comparison readers expect; Petroff is the one that presses hardest. Both
+belong in a write-up, in that order of prominence and the reverse order of
+difficulty.
+
 It is by some distance the best of the references:
 
 | | min ΔE | worst deficiency | grayscale |
 | --- | --- | --- | --- |
 | category-colors 3.0 | 22.6 ± 1.6 | 9.9 to 16.1 | **7.7** |
 | okabeIto | 21.3 | 8.8 | 0.4 |
+| petroff8 | 20.0 | **11.1** | 2.0 |
 | observable10 | 18.4 | 0.6 | 0.7 |
 | tableau10 | 18.1 | 3.2 | 0.5 |
 | d3category10 | 16.2 | 1.6 | 0.0 |

--- a/bench/run.js
+++ b/bench/run.js
@@ -29,7 +29,7 @@ import { withSeed } from './seed.js';
 const parseArgs = (argv) => {
     const options = {
         colors: 8, trials: 10, seed: 1, names: 0, palettailor: false, colorgorical: false,
-        format: 'text', output: null,
+        qualpal: false, format: 'text', output: null,
     };
 
     for (let i = 0; i < argv.length; i += 1) {
@@ -64,6 +64,7 @@ const parseArgs = (argv) => {
         if (arg === '--colors' || arg === '-n') options.colors = nextInt(arg, { min: 2 });
         else if (arg === '--names') options.names = nextNumber(arg, { min: 0 });
         else if (arg === '--palettailor') options.palettailor = true;
+        else if (arg === '--qualpal') options.qualpal = true;
         else if (arg === '--colorgorical') options.colorgorical = true;
         else if (arg === '--trials' || arg === '-t') options.trials = nextInt(arg, { min: 1 });
         else if (arg === '--seed' || arg === '-s') options.seed = nextInt(arg, { min: 0 });
@@ -86,6 +87,7 @@ const USAGE = `Usage: node bench/run.js [options]
   -s, --seed <n>     Base seed; trial i uses seed + i (default 1)
   --names <w>        Also optimize name difference, at this weight (default 0: off)
   --palettailor      Also generate palettes with Palettailor (downloads its sources once)
+  --qualpal          Also generate with QualPal, in two configurations (needs python3)
   --colorgorical     Score every palette on Colorgorical's criteria too, and include its
                      sample palettes if bench/colorgorical/samples.json exists (needs Docker)
   -f, --format <t>   text (default) or json
@@ -132,7 +134,9 @@ const referencePalettes = (colorCount) =>
         }));
 
 // Mean ± sd of every metric over one generator's trials, plus its best trial.
-const summarizeTrials = (generated) => {
+// `deterministic` marks a generator that returns one palette for a given
+// configuration, so a spread over its "trials" would describe nothing.
+const summarizeTrials = (generated, { deterministic = false } = {}) => {
     const scores = generated.map((g) => g.score);
     const best = generated.reduce((a, b) => (b.score.minDeltaE > a.score.minDeltaE ? b : a));
     return {
@@ -146,6 +150,7 @@ const summarizeTrials = (generated) => {
             CVD_CONDITIONS.map((c) => [c.label, aggregate(scores, (s) => s.cvd[c.label])])
         ),
         best: { seed: best.seed, colors: best.colors, score: best.score },
+        deterministic,
         trials: generated,
     };
 };
@@ -209,6 +214,19 @@ const colorgoricalSamples = (colorCount) => {
     );
 };
 
+// The generators present in a result, in report order. One QualPal run yields
+// two configurations, so this is the only place that knows how many rows a
+// generator contributes; adding another is one entry here rather than a new
+// name threaded through the scorer and every table.
+const generatorEntries = (result) =>
+    [
+        ['category-colors', result.generated],
+        ['qualpal', result.qualpal],
+        ['qualpal-defaults', result.qualpalDefaults],
+        ['palettailor', result.palettailor],
+        ['colorgorical', result.colorgorical],
+    ].filter(([, summary]) => summary);
+
 const run = async (options) => {
     const { colors: colorCount, trials, seed, names: namesWeight } = options;
 
@@ -243,6 +261,28 @@ const run = async (options) => {
         palettailor = summarizeTrials(runs);
     }
 
+    // QualPal is deterministic and takes no seed, so each configuration
+    // contributes exactly one palette rather than a distribution.
+    //
+    // Both rows use QualPal's own default colorspace and differ only in whether
+    // CVD adaptation is on, so the gap between them measures that one thing.
+    // An earlier version varied the box as well and credited the box's effect
+    // to CVD. bench/qualpal/readme.md carries the matched-box control, which is
+    // the separate question of how much of any gap is search space.
+    let qualpal = null;
+    let qualpalDefaults = null;
+    if (options.qualpal) {
+        const { generateQualpal, QUALPAL_DEFAULT_BOX, ALL_CVD } = await import('./qualpal/run.js');
+        const one = (cvd) => {
+            const colors = generateQualpal({ colorCount, cvd, colorspace: QUALPAL_DEFAULT_BOX });
+            return summarizeTrials([{ seed: null, colors, score: scorePalette(colors) }], {
+                deterministic: true,
+            });
+        };
+        qualpal = one(ALL_CVD);
+        qualpalDefaults = one(null);
+    }
+
     const references = available.map((entry) => ({
         ...entry,
         score: scorePalette(entry.colors),
@@ -251,15 +291,14 @@ const run = async (options) => {
     const result = {
         options: { colorCount, trials, seed, namesWeight },
         generated: summarizeTrials(generated),
+        qualpal,
+        qualpalDefaults,
         palettailor,
         colorgorical: options.colorgorical ? colorgoricalSamples(colorCount) : null,
         references,
     };
     if (options.colorgorical) {
-        attachColorgorical(
-            [result.generated, result.palettailor, result.colorgorical].filter(Boolean),
-            references
-        );
+        attachColorgorical(generatorEntries(result).map(([, summary]) => summary), references);
     }
     return result;
 };
@@ -273,13 +312,17 @@ const pad = (value, width, align = 'right') => {
 
 const num = (value, digits = 1) => value.toFixed(digits);
 
+// A statistic as `mean±sd`, or bare for a generator that only ever produces one
+// palette. Every table that prints a generator's numbers needs this decision,
+// so it lives in one place.
+const spread = (summary, stat, digits = 1) =>
+    summary.deterministic
+        ? num(stat.mean, digits)
+        : `${num(stat.mean, digits)}±${num(stat.sd, digits)}`;
+
 const formatText = (result) => {
-    const { options, generated, palettailor, colorgorical, references } = result;
-    const generators = [
-        ['category-colors', generated],
-        ['palettailor', palettailor],
-        ['colorgorical', colorgorical],
-    ].filter(([, summary]) => summary);
+    const { options, generated, references } = result;
+    const generators = generatorEntries(result);
     const lines = [];
 
     lines.push(
@@ -299,16 +342,20 @@ const formatText = (result) => {
         `${pad(uniformity, 8)}${pad(minCvd, 14)}${pad(minName, 12)}`;
 
     const generatorRows = (name, summary) => {
+        // A deterministic generator contributes one palette, so "± 0.0" would
+        // claim a stability it never measured and "best trial" would repeat the
+        // row above it. Print the single palette's scores plainly instead.
         lines.push(
             row(
                 name,
-                `${num(summary.minDeltaE.mean)}±${num(summary.minDeltaE.sd)}`,
-                `${num(summary.meanDeltaE.mean)}±${num(summary.meanDeltaE.sd)}`,
+                spread(summary, summary.minDeltaE),
+                spread(summary, summary.meanDeltaE),
                 num(summary.uniformity.mean, 3),
-                `${num(summary.minCvdDeltaE.mean)}±${num(summary.minCvdDeltaE.sd)}`,
-                `${num(summary.minNameDifference.mean, 2)}±${num(summary.minNameDifference.sd, 2)}`
+                spread(summary, summary.minCvdDeltaE),
+                spread(summary, summary.minNameDifference, 2)
             )
         );
+        if (summary.deterministic) return;
         lines.push(
             row(
                 '  best trial',
@@ -352,9 +399,11 @@ const formatText = (result) => {
     lines.push('─'.repeat(60));
     for (const condition of CVD_CONDITIONS) {
         const parts = [`${pad(condition.label, 20, 'left')}`];
-        parts.push(`generated ${pad(num(generated.cvd[condition.label].mean), 6)}`);
-        if (palettailor) {
-            parts.push(`   palettailor ${pad(num(palettailor.cvd[condition.label].mean), 6)}`);
+        // Every generator that ran, not a hardcoded two: this block is the only
+        // place the per-condition argument is visible, and the grayscale row is
+        // what the whole comparison turns on.
+        for (const [name, summary] of generators) {
+            parts.push(`${name} ${pad(num(summary.cvd[condition.label].mean), 6)}  `);
         }
         const worst = references.reduce(
             (a, b) => (b.score.cvd[condition.label] < a.score.cvd[condition.label] ? b : a)
@@ -379,8 +428,8 @@ const formatText = (result) => {
                     Object.fromEntries(
                         COLORGORICAL_CRITERIA.map(({ key }) => [
                             key,
-                            `${num(summary.colorgorical[key].mean, key === 'nd' || key === 'nu' ? 2 : 1)}` +
-                            `±${num(summary.colorgorical[key].sd, key === 'nd' || key === 'nu' ? 2 : 1)}`,
+                            spread(summary, summary.colorgorical[key],
+                                key === 'nd' || key === 'nu' ? 2 : 1),
                         ])
                     )
                 )
@@ -405,7 +454,13 @@ const formatText = (result) => {
 
     lines.push('');
     for (const [name, summary] of generators) {
-        lines.push(`Best ${name} palette (seed ${summary.best.seed}):`);
+        // A deterministic generator has no seed and only one palette, so
+        // "best" and a seed number would both misdescribe it.
+        lines.push(
+            summary.deterministic
+                ? `${name} palette (deterministic):`
+                : `Best ${name} palette (seed ${summary.best.seed}):`
+        );
         lines.push(`  ${summary.best.colors.join(' ')}`);
     }
 

--- a/bench/run.js
+++ b/bench/run.js
@@ -122,9 +122,19 @@ const generateOne = (colorCount, seed, namesWeight) =>
         return final.colors.map(String);
     });
 
+// Truncating a published palette assumes its author meant the first n to be
+// usable on their own, which is true of tableau20 and the rest. Petroff runs a
+// separate optimization per length -- petroff8 is not the first eight of
+// petroff10 -- so truncating one measures a palette nobody designed or ships.
+// These are compared only at the length they were built for.
+const EXACT_LENGTH_ONLY = new Set(['petroff6', 'petroff8', 'petroff10']);
+
 const referencePalettes = (colorCount) =>
     Object.entries(palettes)
-        .filter(([, colors]) => colors.length >= colorCount)
+        .filter(([name, colors]) =>
+            EXACT_LENGTH_ONLY.has(name)
+                ? colors.length === colorCount
+                : colors.length >= colorCount)
         .map(([name, colors]) => ({
             name,
             // Truncating rather than sampling: these palettes are published in

--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,23 @@
   axis this library still leads. At 22.6 this release also clears `okabeIto`
   (21.3) on the mean, though four of ten trials do not.
 
+### Added
+
+- **`petroff6`, `petroff8` and `petroff10`** join `palettes`. Petroff's
+  accessible colour cycles are the nearest published work to this library's
+  objective: minimum perceptual distance under simulated CVD, plus an explicit
+  minimum *lightness* separation for grayscale, plus an aesthetic-preference
+  model. They are the only other palettes in the comparison set with any
+  grayscale constraint, which makes them the comparison this library's claim
+  most needs to survive. Measured at eight colours, `petroff8` scores the best
+  worst-deficiency of any reference (11.1, against Okabe-Ito's 8.8) and a
+  grayscale minimum of 2.0 — better than every other reference and still well
+  below the 7.7 here.
+
+  Each length is optimized separately, so `petroff8` is not the first eight of
+  `petroff10`. The benchmark compares them only at their own length rather than
+  truncating, which is what it does with every other reference.
+
 ## 2.0.1
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## 3.0.0
+
+### Changed
+
+- **The CVD weights drop sharply, and the palettes get better separated
+  without getting less accessible.** `createDefaultConfig()` carried its four
+  CVD terms at 0.3 (protanopia), 0.3 (deuteranopia), 0.2 (tritanopia) and 0.1
+  (grayscale) against an unimpaired `jnd` term of 0.3 — about 60% of the whole
+  objective. They now sit at 0.1 / 0.1 / 0.1 / 0.05 against an unimpaired term
+  of 1.
+
+  Anyone generating palettes with the defaults will get different palettes.
+  Measured over ten seeds at eight colors:
+
+  | | 2.0.x | 3.0 |
+  | --- | --- | --- |
+  | minimum ΔE | 19.0 | 22.6 |
+  | minimum ΔE, deuteranopia | 16.1 | 16.3 |
+  | minimum ΔE, protanopia | 16.2 | 14.9 |
+  | minimum ΔE, tritanopia | 17.2 | 15.6 |
+  | minimum ΔE, grayscale | 7.9 | 7.7 |
+  | **worst pair, all six conditions** | **7.9** | **7.7** |
+
+  2.0.0 moved these terms in the other direction and was right to; this is not
+  a reversal of that decision but a correction to how hard it was pushed. The
+  terms saturate. Two thirds of the weight they carried bought 0.2 of
+  worst-case protection and cost 3.6 points of ordinary separation.
+
+  The reason is visible in the rows above: **worst-case is pinned to grayscale
+  in both configurations**, never to a deficiency. The red-green terms were
+  defending a margin that was never the binding constraint, so relaxing them
+  spends nothing that mattered. Grayscale stays at 0.05, where its own score
+  plateaus.
+
+  To restore the old behaviour, raise the four CVD weights and lower the
+  unimpaired `jnd` term; the readme shows the shape of the trade.
+
+- **A note on where the headroom came from.** Benchmarking QualPal (Larsson) is
+  what prompted this. With its CVD adaptation on it reaches a worst-deficiency
+  ΔE of 21.8 and a plain minimum of 24.7 — better than this library on both,
+  before and after this change. That is what made it clear the deficiency
+  weights here were buying margin that was not winning anything, while the
+  plain-separation number lagged every other generator. What QualPal has no
+  term for is grayscale, where it scores 0.9 against 7.7 here, so print is the
+  axis this library still leads. At 22.6 this release also clears `okabeIto`
+  (21.3) on the mean, though four of ten trials do not.
+
 ## 2.0.1
 
 ### Fixed
@@ -117,3 +164,135 @@
 ## 1.0.0
 
 First npm release.
+
+The code began in March 2022 as a single 307-line script accompanying the
+essay: you edited constants at the top of `index.js`, ran `node index.js`, and
+read the palette out of the console. What follows is what changed between that
+script and this package. None of it is a change anyone had to upgrade through,
+because there was no earlier release — but the script circulated with the essay
+for four years, so this is what is different if that is the version you know.
+
+### Added
+
+- **A public API.** The optimizer is importable rather than something you edit
+  in place: `prepareInitialState`, `runSimulatedAnnealing`,
+  `runWithOrderOptimization`, `cost`, `costBreakdown`, `simulateCvd`,
+  `createDefaultConfig`, `createDefaultState`, `deltaE`, `createColor`,
+  `getChannels`, `palettes`, and `reportJndIssues`. Four subpath exports
+  (`/report`, `/evaluators`, `/evaluators/saliency`, `/cli`) let callers take
+  parts without the whole. The main entry is browser-safe — nothing reachable
+  from it imports a Node builtin, and a test enforces that.
+
+- **A command line.** `category-colors run` generates a palette without editing
+  project files, taking config and state from module paths and writing text,
+  JSON, or a bare palette array. `category-colors report` audits an existing
+  palette for pairs below a just-noticeable-difference threshold, with
+  repeatable `--cvd type:severity` simulations.
+
+- **Pluggable evaluators.** The cost function was six weights hardcoded in one
+  closure. It is now `config.evalFunctions`, an array of
+  `{ function, weight, ...options }` descriptors, each evaluator reading its
+  parameters off its own descriptor — so the same evaluator can appear several
+  times with different settings, which is what makes several CVD terms possible
+  at once. `costBreakdown` itemizes the total per descriptor.
+
+- **Four new evaluators.** `jnd` penalizes pairs that fall below a
+  just-noticeable difference. `contrast` applies WCAG ratios against a
+  background, and optionally between adjacent colors. `avoid` is the inverse of
+  `similarity`, pushing the palette away from given colors within a radius.
+  `saliency` scores how consistently people name a color, using Heer & Stone's
+  naming model.
+
+- **Per-color constraints.** `fixedColor` excludes a color from mutation,
+  `fixedOrder` pins it during reordering, and `lockedChannels` holds some
+  channels while the rest vary — locking a brand hue while saturation and
+  lightness move to meet a contrast requirement, for instance. `examples/`
+  shows each.
+
+- **Order optimization.** `runWithOrderOptimization` reorders the annealed
+  palette so neighboring swatches sit at even perceptual distances. Exhaustive
+  below ten colors and a pairwise-swap local search above, because exhaustive
+  search is O(n!).
+
+- **A loss curve.** `recordHistory` collects `[iteration, cost]` samples on the
+  returned state, which is what you need to plot convergence.
+
+- **Six reference palettes** at `palettes`: `observable10`, `d3category10`,
+  `carbon`, `tableau10`, `tableau20`, and `colorBrewer3_10`. For comparison, or
+  as similarity targets.
+
+- **Tests and CI.** 54 tests on the built-in Node runner, run against Node
+  22.12 and 24. A second CI job packs the tarball, installs it into a scratch
+  project, and imports every subpath, so a broken `exports` map or a file
+  missing from `files` fails before publish rather than after.
+
+- **A benchmark harness**, in `bench/`, scoring generated palettes against the
+  reference palettes on the same measurements, with `Math.random` replaced by a
+  seeded generator so a given `--seed` reproduces the table exactly. It ships
+  with the repository, not the package.
+
+### Changed
+
+- **chroma-js gives way to culori**, by way of colorjs.io, which the port went
+  through first. `munkres-algorithm` joins it so `similarity` can match palette
+  to target by optimal assignment rather than by greedy nearest-neighbor, which
+  could match several colors to the same target.
+
+- **CVD simulation moves from Brettel, Viénot and Mollon (1997) to Machado,
+  Oliveira and Fernandes (2009)**, via culori's deficiency filters — replacing
+  a hand-inlined implementation of the former, sRGB lookup table and all. The
+  essay's images were made with the 1997 model, so the code no longer matches
+  them.
+
+- **The objective penalizes the closest pair rather than the average.** The
+  2022 cost function scored `100 − mean distance` under each condition. A high
+  mean hides a bad minimum, and the minimum is the pair a reader actually
+  confuses, so `jnd` charges `(threshold / ΔE) ** 4` per pair instead: near zero
+  while a pair is comfortably separated, rising steeply once it is not.
+
+- **The default CVD terms go from three to two, and from dichromacy to anomaly
+  at half severity** — protanomaly at weight 0.15 and deuteranomaly at 0.5,
+  weighted by prevalence instead of the flat 0.33 each the script gave
+  protanopia, deuteranopia and tritanopia. 2.0.0 reverses the anomaly half of
+  this decision on measurement; see above.
+
+- **The working space and the distance metric are both configurable.** The
+  script mutated in RGB and measured with chroma's `deltaE`, both hardcoded.
+  `config.colorSpace` now takes any culori mode with per-channel ranges —
+  `okhsl` by default — and detects cyclic channels such as hue from the mode
+  definition rather than special-casing them. `config.colorDistance` picks the
+  method and the space it is measured in.
+
+- **The annealing schedule tunes itself.** The starting temperature was
+  hardcoded at 1000; it is now derived by sampling random mutations for a
+  target acceptance rate. Mutation distance scales with temperature between
+  `minMutationDistance` and `maxMutationDistance` rather than being a fixed
+  ±0.05 nudge on one RGB channel, `maxIterations` caps the run regardless of
+  temperature, and the cooling rate moves from 0.99 to 0.999.
+
+- **Cost is carried on the state instead of recomputed.** The 2022 loop called
+  `cost()` three times per move, each one a full pass over every pair under
+  every simulation. Distance options and distance matrices are cached as well.
+
+- **State preparation no longer mutates the config it is handed.**
+
+- **ESM, with side effects declared** so a bundler can drop what you do not
+  import — which matters because `saliency` carries a ~150 kB lookup table.
+  Node 22.12 is the floor: it is the first release where `require()` can load
+  an ESM package, so CommonJS callers still work without a build step.
+
+- **Renamed from `categorycolors`**, and licensed MIT in `package.json`, which
+  had said ISC while the license file said MIT.
+
+### Documentation
+
+- The readme goes from 30 lines listing which constants to edit to 356
+  covering install, the API, the CLI, bundle size, configuration, channel
+  locking, contrast, avoid, custom evaluators, and JND reporting.
+
+- **Every evaluator names the work behind it**: CIEDE2000 (Sharma, Wu and
+  Dalal, 2005), the CVD model (Machado, Oliveira and Fernandes, 2009), the
+  just-noticeable-difference model (Stone, Szafir and Setlur, 2014), and the
+  color-naming model behind `saliency` (Heer and Stone, 2012).
+  `bench/related-work.md` places the library in that literature, and
+  `bench/references.bib` carries the citations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "category-colors",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Generate perceptually distinguishable color palettes for categorical data visualization using simulated annealing",
   "keywords": [
     "color",

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ const initialState = prepareInitialState(createDefaultState(), config);
 const finalState = runWithOrderOptimization(initialState, config);
 
 console.log(finalState.colors.map(String));
-// [ '#3b4755', '#cb5f8b', '#d9e5e8', ... ]
+// [ '#eedfda', '#b19aca', '#5b9590', ... ]
 ```
 
 `prepareInitialState` fills the palette out to `config.colorCount`, clamps every
@@ -183,24 +183,31 @@ with different settings:
 ### Color vision, and the trade it makes
 
 The default `evalFunctions` carries four `jnd` terms under simulation:
-protanopia and deuteranopia at weight 0.3 each, tritanopia at 0.2, and
-grayscale at 0.1. They model full dichromacy rather than a milder anomaly,
-because optimizing the harder case carries the milder one.
+protanopia, deuteranopia and tritanopia at weight 0.1 each, and grayscale at
+0.05, against an unimpaired `jnd` term at 1. They model full dichromacy rather
+than a milder anomaly, because optimizing the harder case carries the milder
+one.
 
-**This costs ordinary separation, on purpose.** Measured over ten seeds at
-eight colors, against a configuration with no CVD terms beyond the previous
-default:
+**Those weights look too low, and are not.** These terms saturate early:
+past a certain point they stop buying protection and only take separation from
+everything else. Measured over ten seeds at eight colors, against the 2.0.x
+weights (0.3 / 0.3 / 0.2 / 0.1 against an unimpaired 0.3):
 
-| | before | after |
+| | 2.0.x | current |
 | --- | --- | --- |
-| minimum ΔE | 23.8 | 19.0 |
-| minimum ΔE, deuteranopia | 8.9 | 16.1 |
-| minimum ΔE, protanopia | 11.7 | 16.2 |
-| minimum ΔE, tritanopia | 10.6 | 17.2 |
-| minimum ΔE, grayscale | 0.8 | 7.9 |
+| minimum ΔE | 19.0 | 22.6 |
+| minimum ΔE, deuteranopia | 16.1 | 16.3 |
+| minimum ΔE, protanopia | 16.2 | 14.9 |
+| minimum ΔE, tritanopia | 17.2 | 15.6 |
+| minimum ΔE, grayscale | 7.9 | 7.7 |
 
-If you do not need that, raise the unimpaired `jnd` weight or drop the terms
-you do not want, and the separation comes back:
+The number that decides whether a reader confuses two categories is the worst
+pair across *every* condition, and that is pinned to the grayscale row in both
+configurations — 7.9 against 7.7. The 3.6 points of ordinary separation came
+out of red-green headroom that was never the binding constraint.
+
+To trade back the other way, raise the CVD weights or lower the unimpaired
+`jnd` term. To drop conditions entirely:
 
 ```js
 const config = createDefaultConfig();

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ load it.
 
 - `createDefaultConfig()` / `createDefaultState()` — starting points to spread and edit.
 - `evaluators` — every evaluator, as an object, for building `evalFunctions` dynamically. Also exported individually (`energy`, `range`, `jnd`, `similarity`, `avoid`, `contrast`, `saliency`). `names` lives only at `category-colors/evaluators/names`.
-- `palettes` — established categorical palettes (`observable10`, `d3category10`, `carbon`, `tableau10`, `tableau20`, `colorBrewer3_10`, `okabeIto`) for comparison or as seeds.
+- `palettes` — established categorical palettes (`observable10`, `d3category10`, `carbon`, `tableau10`, `tableau20`, `colorBrewer3_10`, `okabeIto`, `petroff6`, `petroff8`, `petroff10`) for comparison or as seeds. Petroff optimizes each length separately, so `petroff8` is not the first eight of `petroff10`; take the one matching your color count.
 
 ### Color utilities
 

--- a/src/config/defaultConfig.js
+++ b/src/config/defaultConfig.js
@@ -2,40 +2,47 @@ import { energy, range, jnd, similarity } from '../evaluators/index.js';
 
 const createDefaultConfig = () => ({
     // The CVD terms model full dichromacy rather than anomalous trichromacy at
-    // half severity. Optimizing the harder case carries the milder one, and it
-    // is what the numbers improved on: measured over ten seeds at eight colors,
-    // moving from anomaly-at-0.5 to dichromacy lifted the minimum deltaE under
-    // deuteranopia from 8.9 to 20.3 and under protanopia from 11.7 to 19.9,
-    // for about one point of unimpaired separation.
+    // half severity, because optimizing the harder case carries the milder one.
     //
-    // Weights are deliberately unequal. Tritanopia is rarer than the red-green
-    // deficiencies, and grayscale is a print concern rather than a vision one,
-    // so both sit below them. Grayscale is held low on evidence: past about
-    // 0.05 its own score stops improving and it only takes separation from the
-    // others. Raise the unimpaired `jnd` weight to trade CVD headroom back for
-    // ordinary separation.
+    // They are weighted far lower than the unimpaired term, which looks wrong
+    // until you measure it: these terms saturate early. 2.0.x carried them at
+    // 0.3/0.3/0.2/0.1 against an unimpaired weight of 0.3 — 60% of the
+    // objective — and bought almost nothing for the last two thirds of that.
+    // Measured over ten seeds at eight colors, moving to the weights below
+    // raised the unimpaired minimum deltaE from 19.0 to 22.6 while the worst
+    // case across all six conditions moved only 7.9 -> 7.7:
+    //
+    //   deuteranopia 16.1 -> 16.3   protanopia 16.2 -> 14.9
+    //   tritanopia   17.2 -> 15.6   grayscale   7.9 ->  7.7
+    //
+    // The binding constraint is grayscale, not the deficiencies: worst-case is
+    // pinned to the grayscale row in both configurations, so the surplus came
+    // out of red-green headroom that was never the limit. Grayscale itself
+    // stays low because its own score stops improving past about 0.05 and only
+    // takes separation from the other terms. Lower the unimpaired `jnd` weight
+    // to trade ordinary separation back for more CVD headroom.
     evalFunctions: [
         { function: energy, weight: 0.15 },
         { function: range, weight: 0.15 },
-        { function: jnd, weight: 0.3 },
+        { function: jnd, weight: 1 },
         {
             function: jnd,
-            weight: 0.3,
+            weight: 0.1,
             cvd: { type: 'protanopia', severity: 1 },
         },
         {
             function: jnd,
-            weight: 0.3,
+            weight: 0.1,
             cvd: { type: 'deuteranopia', severity: 1 },
         },
         {
             function: jnd,
-            weight: 0.2,
+            weight: 0.1,
             cvd: { type: 'tritanopia', severity: 1 },
         },
         {
             function: jnd,
-            weight: 0.1,
+            weight: 0.05,
             cvd: { type: 'grayscale', severity: 1 },
         },
         { function: similarity, weight: 1 },

--- a/src/data/palettes.js
+++ b/src/data/palettes.js
@@ -114,4 +114,54 @@ const okabeIto = [
     createColor('#000000'), // black
 ];
 
-export { observable10, d3category10, carbon, tableau10, tableau20, colorBrewer3_10, okabeIto };
+// Petroff's accessible colour cycles: minimum-perceptual-distance constraints
+// under simulated CVD, a minimum *lightness* separation for grayscale, and an
+// aesthetic-preference model trained on a survey. The nearest work to this
+// library's objective, and the only other palette here with an explicit
+// grayscale constraint.
+//
+// Unlike every other reference here, each length is optimized separately --
+// petroff8 is not the first eight of petroff10 -- so truncating one to compare
+// at another length measures a palette Petroff did not design. Use the entry
+// matching the colour count.
+//
+//   Petroff, M. A. "Accessible Color Sequences for Data Visualization." 2021.
+//   arXiv:2107.02270. Values quoted from the "Final results" section of
+//   github.com/mpetroff/accessible-color-cycles (MIT).
+const petroff6 = [
+    createColor('#5790fc'),
+    createColor('#f89c20'),
+    createColor('#e42536'),
+    createColor('#964a8b'),
+    createColor('#9c9ca1'),
+    createColor('#7a21dd'),
+];
+
+const petroff8 = [
+    createColor('#1845fb'),
+    createColor('#ff5e02'),
+    createColor('#c91f16'),
+    createColor('#c849a9'),
+    createColor('#adad7d'),
+    createColor('#86c8dd'),
+    createColor('#578dff'),
+    createColor('#656364'),
+];
+
+const petroff10 = [
+    createColor('#3f90da'),
+    createColor('#ffa90e'),
+    createColor('#bd1f01'),
+    createColor('#94a4a2'),
+    createColor('#832db6'),
+    createColor('#a96b59'),
+    createColor('#e76300'),
+    createColor('#b9ac70'),
+    createColor('#717581'),
+    createColor('#92dadd'),
+];
+
+export {
+    observable10, d3category10, carbon, tableau10, tableau20, colorBrewer3_10,
+    okabeIto, petroff6, petroff8, petroff10,
+};


### PR DESCRIPTION
Closes the neighbour set in `bench/`, retunes the shipped defaults on what that
measurement showed, and restates the claim on what survives it.

## 3.0.0 — the defaults change

The four CVD terms carried ~60% of the objective and had saturated. Worst case
across conditions is pinned to **grayscale** in every configuration, never to a
deficiency, so the red-green terms were defending a margin nothing was
contesting. Weights move to `0.1 / 0.1 / 0.1 / 0.05` against an unimpaired
`jnd` of 1.

| | 2.0.x | 3.0 |
| --- | --- | --- |
| minimum ΔE | 19.0 | 22.6 |
| deuteranopia | 16.1 | 16.3 |
| protanopia | 16.2 | 14.9 |
| tritanopia | 17.2 | 15.6 |
| grayscale | 7.9 | 7.7 |
| **worst pair, all six** | **7.9** | **7.7** |

Not a reversal of 2.0.0, which moved these terms in the right direction — a
correction to how hard it was pushed. Two costs are recorded rather than
buried: color-buddy's deuteranopia and tritanopia rules each drop from 10/10 to
8/10, and four of ten trials still land at or below `okabeIto`'s 21.3.

## Three neighbours measured

- **QualPal** (`bench/qualpal`) — the strongest competitor. Beats this library
  on plain separation (24.7) and on worst deficiency (21.8 vs 13.7, with all
  ten of our trials below it). Has no luminance term, so grayscale is 0.9.
- **Petroff** — `petroff6/8/10` join `palettes`. Best worst-deficiency of any
  reference (11.1) and best reference grayscale (2.0). Its lightness constraint
  is real and simply set lower than ours.
- **CatPAW** (`bench/catpaw`) — five hand-captured palettes, scored with the
  category error stated up front: it optimizes task accuracy under redundant
  colour-and-shape encoding, which this benchmark cannot measure.

## The claim, narrowed

From "better than the published generators" to: **the worst pair across
unimpaired vision, five simulated deficiencies and a grayscale projection.**
Grayscale is the only axis with a structural gap — nothing else measured has a
luminance term.

## A bug found in QualPal 1.1.0

Its documented Python class validates `cvd`, `metric` and `background`, stores
them, then calls C++ entry points that accept none of them; every setting
returns a byte-identical palette. The runner calls `generate_palette_unified`
and verifies on every CVD run that the option actually took effect.

74/74 tests pass. `references.bib` has no unverified entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CufjcLaRCWuyjUGE5iPKzQ